### PR TITLE
Fix an error when creating a volume

### DIFF
--- a/deploy/kubernetes/latest/sample_app/storageclass.yaml
+++ b/deploy/kubernetes/latest/sample_app/storageclass.yaml
@@ -5,3 +5,4 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -364,8 +364,9 @@ func (c *cloud) GetDiskByName(ctx context.Context, name string, capacityBytes in
 	}
 
 	return &Disk{
-		VolumeID:    aws.StringValue(volume.VolumeId),
-		CapacityGiB: volSizeBytes,
+		VolumeID:         aws.StringValue(volume.VolumeId),
+		CapacityGiB:      volSizeBytes,
+		AvailabilityZone: aws.StringValue(volume.AvailabilityZone),
 	}, nil
 }
 
@@ -382,8 +383,9 @@ func (c *cloud) GetDiskByID(ctx context.Context, volumeID string) (*Disk, error)
 	}
 
 	return &Disk{
-		VolumeID:    aws.StringValue(volume.VolumeId),
-		CapacityGiB: aws.Int64Value(volume.Size),
+		VolumeID:         aws.StringValue(volume.VolumeId),
+		CapacityGiB:      aws.Int64Value(volume.Size),
+		AvailabilityZone: aws.StringValue(volume.AvailabilityZone),
 	}, nil
 }
 

--- a/pkg/cloud/fakes.go
+++ b/pkg/cloud/fakes.go
@@ -52,8 +52,9 @@ func (c *FakeCloudProvider) CreateDisk(ctx context.Context, volumeName string, d
 	r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
 	d := &fakeDisk{
 		Disk: &Disk{
-			VolumeID:    fmt.Sprintf("vol-%d", r1.Uint64()),
-			CapacityGiB: util.BytesToGiB(diskOptions.CapacityBytes),
+			VolumeID:         fmt.Sprintf("vol-%d", r1.Uint64()),
+			CapacityGiB:      util.BytesToGiB(diskOptions.CapacityBytes),
+			AvailabilityZone: diskOptions.AvailabilityZone,
 		},
 		tags: diskOptions.Tags,
 	}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -86,14 +86,17 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 	}
 
+	volumeParams := req.GetParameters()
+	fsType := volumeParams["fsType"]
+
 	// volume exists already
 	if disk != nil {
+		disk.FsType = fsType
 		return newCreateVolumeResponse(disk), nil
 	}
 
 	// create a new volume
 	zone := pickAvailabilityZone(req.GetAccessibilityRequirements())
-	volumeParams := req.GetParameters()
 	volumeType := volumeParams["type"]
 	iopsPerGB := 0
 	if volumeType == cloud.VolumeTypeIO1 {
@@ -125,7 +128,6 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not create volume %q: %v", volName, err)
 	}
-	fsType := volumeParams["fsType"]
 	disk.FsType = fsType
 	return newCreateVolumeResponse(disk), nil
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
* In the waitForVolume case "creating" incorrectly returned an error. This would then return from `cloud.CreateDisk`, causing a possible race condition. Where the function driver.CreateVolume could create another disk with the same `com.amazon.aws.csi.volume` tag. Eventually erroring with `ErrMultiDisks`. This also exposed a bug where the `AvailabilityZone` and `fsType` were not properly set. Which only surfaced when setting `--feature-gates=Topology=true`.
* Added `volumeBindingMode: WaitForFirstConsumer` in the StorageClass because since the flag `--feature-gates=Topology=true` is set and it is required for that feature.

**What testing is done?** 
Manual testing and new unit tests

Error `volume vol-0fff33f4c0834292a is still being created` returned
```
$ kubectl describe pvc

Events:
  Type       Reason                 Age                From                                                                    Message
  ----       ------                 ----               ----                                                                    -------
  Warning    ProvisioningFailed     39s                persistentvolume-controller                                             storageclass.storage.k8s.io "slow" not found
  Warning    ProvisioningFailed     29s                ebs.csi.aws.com_csi-provisioner-0_87553ac8-0499-11e9-a00f-06f965927db1  failed to provision volume with StorageClass "slow": rpc error: code = Internal desc = Could not create volume "pvc-0ba471eb-0482-11e9-b7b3-22df1a95de60": failed to get an available volume in EC2: volume vol-0fff33f4c0834292a is still being created
  Normal     ExternalProvisioning   18s (x3 over 33s)  persistentvolume-controller                                             waiting for a volume to be created, either by external provisioner "ebs.csi.aws.com" or manually created by system administrator
  Normal     Provisioning           14s (x2 over 33s)  ebs.csi.aws.com_csi-provisioner-0_87553ac8-0499-11e9-a00f-06f965927db1  External provisioner is provisioning volume for claim "default/claim1"
  Normal     ProvisioningSucceeded  14s                ebs.csi.aws.com_csi-provisioner-0_87553ac8-0499-11e9-a00f-06f965927db1  Successfully provisioned volumepvc-0ba471eb-0482-11e9-b7b3-22df1a95de60
Mounted By:  app-5f7dccccc6-wzn9g
```
Then when the PV is created in Kubernetes, `values` field was empty for `matchExpressions`:
```
$ kubectl get pv -o yaml

    nodeAffinity:
      required:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.ebs.csi.aws.com/zone
            operator: In
            values:
            - ""
```
 And the pod would not properly run:
```
$ kubectl describe pods

Events:
  Type     Reason                  Age                 From                                                Message
  ----     ------                  ----                ----                                                -------
  Warning  FailedScheduling        54s (x2 over 54s)   default-scheduler                                   pod has unbound immediate PersistentVolumeClaims
  Normal   Scheduled               30s                 default-scheduler                                   Successfully assigned default/app-5f7dccccc6-t9z8s to kube-node-1-kubelet.devkubernetes01.mesos
  Normal   SuccessfulAttachVolume  26s                 attachdetach-controller                             AttachVolume.Attach succeeded for volume "pvc-0ba471eb-0482-11e9-b7b3-22df1a95de60"
  Warning  FailedMount             20s (x25 over 22s)  kubelet, kube-node-1-kubelet.devkubernetes01.mesos  MountVolume.NodeAffinity check failed for volume "pvc-0ba471eb-0482-11e9-b7b3-22df1a95de60" : No matching NodeSelectorTerms
```

This only really surfaced itself when setting `--feature-gates=Topology=true` since the pod needs to have the proper `nodeAffinity` set in PV spec.